### PR TITLE
Fix link to Javadocs

### DIFF
--- a/src/main/resources/commons-xdoc-templates/readme-md-template.md
+++ b/src/main/resources/commons-xdoc-templates/readme-md-template.md
@@ -54,7 +54,7 @@ Documentation
 -------------
 
 More information can be found on the [@NAME@ homepage](https://commons.apache.org/proper/commons-@ID@).
-The [Javadoc](https://commons.apache.org/proper/commons-@ID@/javadocs/api-release) can be browsed.
+The [Javadoc](https://commons.apache.org/proper/commons-@ID@/apidocs) can be browsed.
 Questions related to the usage of @NAME@ should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?


### PR DESCRIPTION
I noticed, in multiple projects, that in the README.md file, the link to the Javadocs is broken. I think this PR properly fixes this issue.

Examples: https://github.com/sebkur/commons-bcel, https://github.com/apache/commons-codec, look for the "Docmentation" section and the "Javadoc" link.