### PR TITLE
Fix pom syntax

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE xml/>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
@@ -17,7 +16,7 @@
  limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Empty DOCTYPE is cause to parse error on Maven 4

We have something like:

```
[ERROR]   The project (.../repos/apache/commons-build-plugin/pom.xml) has 1 error
[ERROR]     Non-parseable POM .../repos/apache/commons-build-plugin/pom.xml: Unexpected character '/' (code 47) in DOCTYPE declaration; expected '[' or white space.
[ERROR]      at [row,col {unknown-source}]: [2,14] @ line 2, column 14

```