### PR TITLE
Fix broken URL to project location in Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Apache Commons Build Plugin Maven Mojo
 ===================
 
 [![Java CI](https://github.com/apache/commons-build-plugin/actions/workflows/maven.yml/badge.svg)](https://github.com/apache/commons-build-plugin/actions/workflows/maven.yml)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-build-plugin/badge.svg?gav=true)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-build-plugin/?gav=true)
+[![Maven Central](https://img.shields.io/maven-central/v/org.apache.commons/commons-build-plugin?label=Maven%20Central)](https://search.maven.org/artifact/org.apache.commons/commons-build-plugin)
 [![CodeQL](https://github.com/apache/commons-build-plugin/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/apache/commons-build-plugin/actions/workflows/codeql-analysis.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/apache/commons-build-plugin/badge)](https://api.securityscorecards.dev/projects/github.com/apache/commons-build-plugin)
 

--- a/src/main/resources/commons-xdoc-templates/readme-md-template.md
+++ b/src/main/resources/commons-xdoc-templates/readme-md-template.md
@@ -44,7 +44,7 @@
 ===================
 
 [![Java CI](https://github.com/apache/commons-@ID@/actions/workflows/maven.yml/badge.svg)](https://github.com/apache/commons-@ID@/actions/workflows/maven.yml)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/@GROUPID@/@ARTIFACTCOREID@/badge.svg?gav=true)](https://maven-badges.herokuapp.com/maven-central/@GROUPID@/@ARTIFACTCOREID@/?gav=true)
+[![Maven Central](https://img.shields.io/maven-central/v/@GROUPID@/@ARTIFACTCOREID@?label=Maven%20Central)](https://search.maven.org/artifact/@GROUPID@/@ARTIFACTCOREID@)
 [![Javadocs](https://javadoc.io/badge/@GROUPID@/@ARTIFACTCOREID@/@VERSION@.svg)](https://javadoc.io/doc/@GROUPID@/@ARTIFACTCOREID@/@VERSION@)
 [![CodeQL](https://github.com/apache/commons-@ID@/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/apache/commons-@ID@/actions/workflows/codeql-analysis.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/apache/commons-@ID@/badge)](https://api.securityscorecards.dev/projects/github.com/apache/commons-@ID@)


### PR DESCRIPTION
As suggested in [PR #1296](https://github.com/apache/commons-lang/pull/1296#issuecomment-2409604975), this fix addresses the broken Maven Central badge in the source repository.